### PR TITLE
Update bitcoincore-rpc-json

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoincore-rpc-async2"
-version = "4.0.1"
+version = "4.0.2"
 authors = [
     "Jeremy Rubin <j@rubin.io>",
     "Steven Roose <steven@stevenroose.org>",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -20,7 +20,7 @@ name = "bitcoincore_rpc_async"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoincore-rpc-json = "0.15.0"
+bitcoincore-rpc-json = "0.16.0"
 async-trait = "0.1.42"
 log = "0.4.5"
 jsonrpc-async = "2.0.2"

--- a/client/examples/retry_client.rs
+++ b/client/examples/retry_client.rs
@@ -8,11 +8,11 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use async_trait::async_trait;
 use bitcoincore_rpc_async;
 use jsonrpc_async as jsonrpc;
 use serde;
 use serde_json;
-use async_trait::async_trait;
 
 use bitcoincore_rpc_async::{Client, Error, Result, RpcApi};
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -8,12 +8,12 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use serde_json::value::RawValue;
 use std::collections::HashMap;
 use std::fs::File;
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
-use serde_json::value::RawValue;
 
 use super::bitcoin;
 use bitcoincore_rpc_json as json;
@@ -21,14 +21,14 @@ use jsonrpc_async as jsonrpc;
 use serde::*;
 use serde_json;
 
+use async_trait::async_trait;
 use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::secp256k1::Signature;
 use bitcoin::{
     Address, Amount, Block, BlockHeader, OutPoint, PrivateKey, PublicKey, Script, Transaction,
 };
 use log::Level::{Debug, Trace, Warn};
-use log::{log_enabled, debug, trace};
-use async_trait::async_trait;
+use log::{debug, log_enabled, trace};
 
 use crate::error::*;
 use crate::queryable;
@@ -203,7 +203,7 @@ impl Auth {
         use std::io::Read;
         match self {
             Auth::None => Ok(None),
-            Auth::UserPass(u, p) => Ok(Some((u,p))),
+            Auth::UserPass(u, p) => Ok(Some((u, p))),
             Auth::CookieFile(path) => {
                 let mut file = File::open(path)?;
                 let mut contents = String::new();
@@ -230,9 +230,10 @@ pub trait RpcApi: Sized {
     async fn get_by_id<T: queryable::Queryable<Self>>(
         &self,
         id: &<T as queryable::Queryable<Self>>::Id,
-    ) -> Result<T> 
-    where T: Sync + Send ,
-        <T as queryable::Queryable<Self>>::Id : Sync + Send
+    ) -> Result<T>
+    where
+        T: Sync + Send,
+        <T as queryable::Queryable<Self>>::Id: Sync + Send,
     {
         T::query(&self, &id).await
     }
@@ -293,7 +294,8 @@ pub trait RpcApi: Sized {
         self.call(
             "createwallet",
             handle_defaults(&mut args, &[false.into(), false.into(), into_json("")?, false.into()]),
-        ).await
+        )
+        .await
     }
 
     async fn list_wallets(&self) -> Result<Vec<String>> {
@@ -451,7 +453,8 @@ pub trait RpcApi: Sized {
         block_hash: Option<&bitcoin::BlockHash>,
     ) -> Result<Transaction> {
         let mut args = [into_json(txid)?, into_json(false)?, opt_into_json(block_hash)?];
-        let hex: String = self.call("getrawtransaction", handle_defaults(&mut args, &[null()])).await?;
+        let hex: String =
+            self.call("getrawtransaction", handle_defaults(&mut args, &[null()])).await?;
         let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
         Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
     }
@@ -496,7 +499,11 @@ pub trait RpcApi: Sized {
         Ok(self.call("getbalances", &[]).await?)
     }
 
-    async fn get_received_by_address(&self, address: &Address, minconf: Option<u32>) -> Result<Amount> {
+    async fn get_received_by_address(
+        &self,
+        address: &Address,
+        minconf: Option<u32>,
+    ) -> Result<Amount> {
         let mut args = [address.to_string().into(), opt_into_json(minconf)?];
         Ok(Amount::from_btc(
             self.call("getreceivedbyaddress", handle_defaults(&mut args, &[null()])).await?,
@@ -525,7 +532,8 @@ pub trait RpcApi: Sized {
             opt_into_json(skip)?,
             opt_into_json(include_watchonly)?,
         ];
-        self.call("listtransactions", handle_defaults(&mut args, &[10.into(), 0.into(), null()])).await
+        self.call("listtransactions", handle_defaults(&mut args, &[10.into(), 0.into(), null()]))
+            .await
     }
 
     async fn list_since_block(
@@ -610,7 +618,8 @@ pub trait RpcApi: Sized {
         self.call(
             "importaddress",
             handle_defaults(&mut args, &[into_json("")?, true.into(), null()]),
-        ).await
+        )
+        .await
     }
 
     async fn import_multi(
@@ -715,7 +724,8 @@ pub trait RpcApi: Sized {
         locktime: Option<i64>,
         replaceable: Option<bool>,
     ) -> Result<Transaction> {
-        let hex: String = self.create_raw_transaction_hex(utxos, outs, locktime, replaceable).await?;
+        let hex: String =
+            self.create_raw_transaction_hex(utxos, outs, locktime, replaceable).await?;
         let bytes: Vec<u8> = FromHex::from_hex(&hex)?;
         Ok(bitcoin::consensus::encode::deserialize(&bytes)?)
     }
@@ -725,8 +735,9 @@ pub trait RpcApi: Sized {
         tx: R,
         options: Option<&json::FundRawTransactionOptions>,
         is_witness: Option<bool>,
-    ) -> Result<json::FundRawTransactionResult> 
-    where R: Sync + Send
+    ) -> Result<json::FundRawTransactionResult>
+    where
+        R: Sync + Send,
     {
         let mut args = [tx.raw_hex().into(), opt_into_json(options)?, opt_into_json(is_witness)?];
         let defaults = [empty_obj(), null()];
@@ -740,8 +751,9 @@ pub trait RpcApi: Sized {
         utxos: Option<&[json::SignRawTransactionInput]>,
         private_keys: Option<&[PrivateKey]>,
         sighash_type: Option<json::SigHashType>,
-    ) -> Result<json::SignRawTransactionResult> 
-    where R: Sync + Send
+    ) -> Result<json::SignRawTransactionResult>
+    where
+        R: Sync + Send,
     {
         let mut args = [
             tx.raw_hex().into(),
@@ -758,8 +770,9 @@ pub trait RpcApi: Sized {
         tx: R,
         utxos: Option<&[json::SignRawTransactionInput]>,
         sighash_type: Option<json::SigHashType>,
-    ) -> Result<json::SignRawTransactionResult> 
-    where R: Sync + Send
+    ) -> Result<json::SignRawTransactionResult>
+    where
+        R: Sync + Send,
     {
         let mut args = [tx.raw_hex().into(), opt_into_json(utxos)?, opt_into_json(sighash_type)?];
         let defaults = [empty_arr(), null()];
@@ -772,8 +785,9 @@ pub trait RpcApi: Sized {
         privkeys: &[PrivateKey],
         prevtxs: Option<&[json::SignRawTransactionInput]>,
         sighash_type: Option<json::SigHashType>,
-    ) -> Result<json::SignRawTransactionResult> 
-    where R: Sync + Send
+    ) -> Result<json::SignRawTransactionResult>
+    where
+        R: Sync + Send,
     {
         let mut args = [
             tx.raw_hex().into(),
@@ -788,8 +802,9 @@ pub trait RpcApi: Sized {
     async fn test_mempool_accept<R: RawTx>(
         &self,
         rawtxs: &[R],
-    ) -> Result<Vec<json::TestMempoolAcceptResult>> 
-    where R: Sync + Send
+    ) -> Result<Vec<json::TestMempoolAcceptResult>>
+    where
+        R: Sync + Send,
     {
         let hexes: Vec<serde_json::Value> =
             rawtxs.to_vec().into_iter().map(|r| r.raw_hex().into()).collect();
@@ -836,7 +851,11 @@ pub trait RpcApi: Sized {
 
     /// Mine up to block_num blocks immediately (before the RPC call returns)
     /// to an address in the wallet.
-    async fn generate(&self, block_num: u64, maxtries: Option<u64>) -> Result<Vec<bitcoin::BlockHash>> {
+    async fn generate(
+        &self,
+        block_num: u64,
+        maxtries: Option<u64>,
+    ) -> Result<Vec<bitcoin::BlockHash>> {
         self.call("generate", &[block_num.into(), opt_into_json(maxtries)?]).await
     }
 
@@ -887,7 +906,8 @@ pub trait RpcApi: Sized {
                 &mut args,
                 &["".into(), "".into(), false.into(), false.into(), 6.into(), null()],
             ),
-        ).await
+        )
+        .await
     }
 
     /// Returns data about each connected network node as an array of
@@ -910,8 +930,9 @@ pub trait RpcApi: Sized {
         self.call("ping", &[]).await
     }
 
-    async fn send_raw_transaction<R: RawTx>(&self, tx: R) -> Result<bitcoin::Txid> 
-    where R: Sync + Send
+    async fn send_raw_transaction<R: RawTx>(&self, tx: R) -> Result<bitcoin::Txid>
+    where
+        R: Sync + Send,
     {
         self.call("sendrawtransaction", &[tx.raw_hex().into()]).await
     }
@@ -974,7 +995,8 @@ pub trait RpcApi: Sized {
         self.call(
             "walletcreatefundedpsbt",
             handle_defaults(&mut args, &[0.into(), serde_json::Map::new().into(), false.into()]),
-        ).await
+        )
+        .await
     }
 
     async fn get_descriptor_info(&self, desc: &str) -> Result<json::GetDescriptorInfoResult> {
@@ -985,12 +1007,20 @@ pub trait RpcApi: Sized {
         self.call("combinepsbt", &[into_json(psbts)?]).await
     }
 
-    async fn finalize_psbt(&self, psbt: &str, extract: Option<bool>) -> Result<json::FinalizePsbtResult> {
+    async fn finalize_psbt(
+        &self,
+        psbt: &str,
+        extract: Option<bool>,
+    ) -> Result<json::FinalizePsbtResult> {
         let mut args = [into_json(psbt)?, opt_into_json(extract)?];
         self.call("finalizepsbt", handle_defaults(&mut args, &[true.into()])).await
     }
 
-    async fn derive_addresses(&self, descriptor: &str, range: Option<[u32; 2]>) -> Result<Vec<Address>> {
+    async fn derive_addresses(
+        &self,
+        descriptor: &str,
+        range: Option<[u32; 2]>,
+    ) -> Result<Vec<Address>> {
         let mut args = [into_json(descriptor)?, opt_into_json(range)?];
         self.call("deriveaddresses", handle_defaults(&mut args, &[null()])).await
     }
@@ -1050,10 +1080,7 @@ pub struct Client {
 
 impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "bitcoincore_rpc::Client(jsonrpc::client::Client(last_nonce=?))",
-        )
+        write!(f, "bitcoincore_rpc::Client(jsonrpc::client::Client(last_nonce=?))",)
     }
 }
 
@@ -1062,13 +1089,16 @@ impl Client {
     ///
     /// Can only return [Err] when using cookie authentication.
     pub async fn new(url: String, auth: Auth) -> Result<Self> {
-        let mut client = jsonrpc::simple_http::SimpleHttpTransport::builder().url(&url).await.map_err(|e|Error::JsonRpc(e.into()))?;
+        let mut client = jsonrpc::simple_http::SimpleHttpTransport::builder()
+            .url(&url)
+            .await
+            .map_err(|e| Error::JsonRpc(e.into()))?;
         if let Some((user, pass)) = auth.get_user_pass()? {
             client = client.auth(user, Some(pass));
         }
 
         Ok(Client {
-            client: jsonrpc::client::Client::with_transport(client.build())
+            client: jsonrpc::client::Client::with_transport(client.build()),
         })
     }
 
@@ -1093,7 +1123,10 @@ impl RpcApi for Client {
         cmd: &str,
         args: &[serde_json::Value],
     ) -> Result<T> {
-        let v_args : Vec<_> = args.iter().map(serde_json::value::to_raw_value).collect::<std::result::Result<_,serde_json::Error>>()?;
+        let v_args: Vec<_> = args
+            .iter()
+            .map(serde_json::value::to_raw_value)
+            .collect::<std::result::Result<_, serde_json::Error>>()?;
         let req = self.client.build_request(cmd, &v_args[..]);
         if log_enabled!(Debug) {
             debug!(target: "bitcoincore_rpc", "JSON-RPC request: {} {}", cmd, serde_json::Value::from(args));
@@ -1102,7 +1135,6 @@ impl RpcApi for Client {
         let resp = self.client.send_request(req).await.map_err(Error::from);
         log_response(cmd, &resp);
         Ok(resp?.result()?)
-
     }
 }
 
@@ -1120,7 +1152,8 @@ fn log_response(cmd: &str, resp: &Result<jsonrpc::Response>) {
                         debug!(target: "bitcoincore_rpc", "JSON-RPC error for {}: {:?}", cmd, e);
                     }
                 } else if log_enabled!(Trace) {
-                    let rawnull = serde_json::value::to_raw_value(&serde_json::Value::Null).unwrap();
+                    let rawnull =
+                        serde_json::value::to_raw_value(&serde_json::Value::Null).unwrap();
                     let result = resp.result.as_ref().unwrap_or(&rawnull);
                     trace!(target: "bitcoincore_rpc", "JSON-RPC response for {}: {}", cmd, result);
                 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -37,7 +37,6 @@ impl From<jsonrpc::error::Error> for Error {
     }
 }
 
-
 impl From<hex::Error> for Error {
     fn from(e: hex::Error) -> Error {
         Error::Hex(e)

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,15 +13,14 @@
 //! This is a client library for the Bitcoin Core JSON-RPC API.
 //!
 
-
 use log;
 
 use serde;
 use serde_json;
 
 pub use bitcoincore_rpc_json as json;
-pub use jsonrpc_async as jsonrpc;
 pub use json::bitcoin;
+pub use jsonrpc_async as jsonrpc;
 
 mod client;
 mod error;

--- a/client/src/queryable.rs
+++ b/client/src/queryable.rs
@@ -9,8 +9,8 @@
 //
 
 use super::bitcoin;
-use serde_json;
 use super::json;
+use serde_json;
 
 use crate::client::Result;
 use crate::client::RpcApi;

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -7,7 +7,7 @@ publish=false
 
 [dependencies]
 bitcoincore-rpc-async = { package = "bitcoincore-rpc-async2", path = "../client" }
-bitcoin = { version = "0.28.1", features = [ "use-serde", "rand" ] }
+bitcoin = { version = "0.29.0", features = [ "serde", "rand" ] }
 lazy_static = "1.4.0"
 log = "0.4"
 tokio = { version = "1", features = ["full"] }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -18,10 +18,10 @@ use tokio;
 
 use std::collections::HashMap;
 
-use bitcoincore_rpc_async as bitcoincore_rpc;
 use bitcoincore_rpc::json;
 use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
 use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
+use bitcoincore_rpc_async as bitcoincore_rpc;
 
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hashes::hex::{FromHex, ToHex};
@@ -29,7 +29,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1;
 use bitcoin::{
     Address, Amount, Network, OutPoint, PrivateKey, Script, SigHashType, SignedAmount, Transaction,
-    TxIn, TxOut, Txid, Witness
+    TxIn, TxOut, Txid, Witness,
 };
 use bitcoincore_rpc::json::ScanTxOutRequest;
 
@@ -236,7 +236,8 @@ async fn test_generate(cl: &Client) {
 async fn test_get_balance_generate_to_address(cl: &Client) {
     let initial = cl.get_balance(None, None).await.unwrap();
 
-    let blocks = cl.generate_to_address(500, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+    let blocks =
+        cl.generate_to_address(500, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
     assert_eq!(blocks.len(), 500);
     assert_ne!(cl.get_balance(None, None).await.unwrap(), initial);
 }
@@ -245,7 +246,10 @@ async fn test_get_balances_generate_to_address(cl: &Client) {
     if version() >= 190000 {
         let initial = cl.get_balances().await.unwrap();
 
-        let blocks = cl.generate_to_address(500, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+        let blocks = cl
+            .generate_to_address(500, &cl.get_new_address(None, None).await.unwrap())
+            .await
+            .unwrap();
         assert_eq!(blocks.len(), 500);
         assert_ne!(cl.get_balances().await.unwrap(), initial);
     }
@@ -342,12 +346,30 @@ async fn test_set_label(cl: &Client) {
 async fn test_send_to_address(cl: &Client) {
     let addr = cl.get_new_address(None, None).await.unwrap();
     let est = json::EstimateMode::Conservative;
-    let _ = cl.send_to_address(&addr, btc(1.0f64), Some("cc"), None, None, None, None, None).await.unwrap();
-    let _ = cl.send_to_address(&addr, btc(1.0f64), None, Some("tt"), None, None, None, None).await.unwrap();
-    let _ = cl.send_to_address(&addr, btc(1.0f64), None, None, Some(true), None, None, None).await.unwrap();
-    let _ = cl.send_to_address(&addr, btc(1.0f64), None, None, None, Some(true), None, None).await.unwrap();
-    let _ = cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, Some(3), None).await.unwrap();
-    let _ = cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, Some(est)).await.unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), Some("cc"), None, None, None, None, None)
+        .await
+        .unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), None, Some("tt"), None, None, None, None)
+        .await
+        .unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), None, None, Some(true), None, None, None)
+        .await
+        .unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), None, None, None, Some(true), None, None)
+        .await
+        .unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), None, None, None, None, Some(3), None)
+        .await
+        .unwrap();
+    let _ = cl
+        .send_to_address(&addr, btc(1.0f64), None, None, None, None, None, Some(est))
+        .await
+        .unwrap();
 }
 
 async fn test_get_received_by_address(cl: &Client) {
@@ -355,7 +377,8 @@ async fn test_get_received_by_address(cl: &Client) {
     let _ = cl.send_to_address(&addr, btc(1), None, None, None, None, None, None).await.unwrap();
     assert_eq!(cl.get_received_by_address(&addr, Some(0)).await.unwrap(), btc(1));
     assert_eq!(cl.get_received_by_address(&addr, Some(1)).await.unwrap(), btc(0));
-    let _ = cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+    let _ =
+        cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
     assert_eq!(cl.get_received_by_address(&addr, Some(6)).await.unwrap(), btc(1));
     assert_eq!(cl.get_received_by_address(&addr, None).await.unwrap(), btc(1));
 }
@@ -374,7 +397,8 @@ async fn test_list_unspent(cl: &Client) {
         maximum_amount: Some(btc(7)),
         ..Default::default()
     };
-    let unspent = cl.list_unspent(Some(0), None, Some(&[&addr]), None, Some(options)).await.unwrap();
+    let unspent =
+        cl.list_unspent(Some(0), None, Some(&[&addr]), None, Some(options)).await.unwrap();
     assert_eq!(unspent.len(), 1);
     assert_eq!(unspent[0].txid, txid);
     assert_eq!(unspent[0].address.as_ref(), Some(&addr));
@@ -391,7 +415,8 @@ async fn test_get_connection_count(cl: &Client) {
 
 async fn test_get_raw_transaction(cl: &Client) {
     let addr = cl.get_new_address(None, None).await.unwrap();
-    let txid = cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
+    let txid =
+        cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
     let tx = cl.get_raw_transaction(&txid, None).await.unwrap();
     let hex = cl.get_raw_transaction_hex(&txid, None).await.unwrap();
     assert_eq!(tx, deserialize(&Vec::<u8>::from_hex(&hex).unwrap()).unwrap());
@@ -400,7 +425,8 @@ async fn test_get_raw_transaction(cl: &Client) {
     let info = cl.get_raw_transaction_info(&txid, None).await.unwrap();
     assert_eq!(info.txid, txid);
 
-    let blocks = cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+    let blocks =
+        cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
     let _ = cl.get_raw_transaction_info(&txid, Some(&blocks[0])).await.unwrap();
 }
 
@@ -409,8 +435,10 @@ async fn test_get_raw_mempool(cl: &Client) {
 }
 
 async fn test_get_transaction(cl: &Client) {
-    let txid =
-        cl.send_to_address(&RANDOM_ADDRESS, btc(1), None, None, None, None, None, None).await.unwrap();
+    let txid = cl
+        .send_to_address(&RANDOM_ADDRESS, btc(1), None, None, None, None, None, None)
+        .await
+        .unwrap();
     let tx = cl.get_transaction(&txid, None).await.unwrap();
     assert_eq!(tx.amount, sbtc(-1.0));
     assert_eq!(tx.info.txid, txid);
@@ -434,8 +462,10 @@ async fn test_list_since_block(cl: &Client) {
 }
 
 async fn test_get_tx_out(cl: &Client) {
-    let txid =
-        cl.send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
+    let txid = cl
+        .send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None)
+        .await
+        .unwrap();
     let out = cl.get_tx_out(&txid, 0, Some(false)).await.unwrap();
     assert!(out.is_none());
     let out = cl.get_tx_out(&txid, 0, Some(true)).await.unwrap();
@@ -444,18 +474,25 @@ async fn test_get_tx_out(cl: &Client) {
 }
 
 async fn test_get_tx_out_proof(cl: &Client) {
-    let txid1 =
-        cl.send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
-    let txid2 =
-        cl.send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
-    let blocks = cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+    let txid1 = cl
+        .send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None)
+        .await
+        .unwrap();
+    let txid2 = cl
+        .send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None)
+        .await
+        .unwrap();
+    let blocks =
+        cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
     let proof = cl.get_tx_out_proof(&[txid1, txid2], Some(&blocks[0])).await.unwrap();
     assert!(!proof.is_empty());
 }
 
 async fn test_get_mempool_entry(cl: &Client) {
-    let txid =
-        cl.send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
+    let txid = cl
+        .send_to_address(&RANDOM_ADDRESS, btc(1.0f64), None, None, None, None, None, None)
+        .await
+        .unwrap();
     let entry = cl.get_mempool_entry(&txid).await.unwrap();
     assert!(entry.spent_by.is_empty());
 
@@ -465,14 +502,16 @@ async fn test_get_mempool_entry(cl: &Client) {
 
 async fn test_lock_unspent_unlock_unspent(cl: &Client) {
     let addr = cl.get_new_address(None, None).await.unwrap();
-    let txid = cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
+    let txid =
+        cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
 
     assert!(cl.lock_unspent(&[OutPoint::new(txid, 0)]).await.unwrap());
     assert!(cl.unlock_unspent(&[OutPoint::new(txid, 0)]).await.unwrap());
 }
 
 async fn test_get_block_filter(cl: &Client) {
-    let blocks = cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
+    let blocks =
+        cl.generate_to_address(7, &cl.get_new_address(None, None).await.unwrap()).await.unwrap();
     if version() >= 190000 {
         let _ = cl.get_block_filter(&blocks[0]).await.unwrap();
     } else {
@@ -542,8 +581,10 @@ async fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
         }],
     };
 
-    let res =
-        cl.sign_raw_transaction_with_key(&tx, &[sk], None, Some(SigHashType::All.into())).await.unwrap();
+    let res = cl
+        .sign_raw_transaction_with_key(&tx, &[sk], None, Some(SigHashType::All.into()))
+        .await
+        .unwrap();
     assert!(res.complete);
     let _ = cl.send_raw_transaction(&res.transaction().unwrap()).await.unwrap();
 }
@@ -575,9 +616,12 @@ async fn test_create_raw_transaction(cl: &Client) {
     let mut output = HashMap::new();
     output.insert(RANDOM_ADDRESS.to_string(), btc(1.0f64));
 
-    let tx =
-        cl.create_raw_transaction(&[input.clone()], &output, Some(500_000), Some(true)).await.unwrap();
-    let hex = cl.create_raw_transaction_hex(&[input], &output, Some(500_000), Some(true)).await.unwrap();
+    let tx = cl
+        .create_raw_transaction(&[input.clone()], &output, Some(500_000), Some(true))
+        .await
+        .unwrap();
+    let hex =
+        cl.create_raw_transaction_hex(&[input], &output, Some(500_000), Some(true)).await.unwrap();
     assert_eq!(tx, deserialize(&Vec::<u8>::from_hex(&hex).unwrap()).unwrap());
     assert_eq!(hex, serialize(&tx).to_hex());
 }
@@ -638,8 +682,10 @@ async fn test_test_mempool_accept(cl: &Client) {
     let mut output = HashMap::new();
     output.insert(RANDOM_ADDRESS.to_string(), unspent.amount - *FEE);
 
-    let tx =
-        cl.create_raw_transaction(&[input.clone()], &output, Some(500_000), Some(false)).await.unwrap();
+    let tx = cl
+        .create_raw_transaction(&[input.clone()], &output, Some(500_000), Some(false))
+        .await
+        .unwrap();
     let res = cl.test_mempool_accept(&[&tx]).await.unwrap();
     assert!(!res[0].allowed);
     assert!(res[0].reject_reason.is_some());
@@ -687,7 +733,8 @@ async fn test_wallet_create_funded_psbt(cl: &Client) {
             Some(options),
             Some(true),
         )
-        .await.unwrap();
+        .await
+        .unwrap();
 
     let options = json::WalletCreateFundedPsbtOptions {
         add_inputs: Some(true),
@@ -704,7 +751,8 @@ async fn test_wallet_create_funded_psbt(cl: &Client) {
     };
     let psbt = cl
         .wallet_create_funded_psbt(&[input], &output, Some(500_000), Some(options), Some(true))
-        .await.unwrap();
+        .await
+        .unwrap();
     assert!(!psbt.psbt.is_empty());
 }
 
@@ -724,7 +772,8 @@ async fn test_combine_psbt(cl: &Client) {
     output.insert(RANDOM_ADDRESS.to_string(), btc(1.0f64));
     let psbt1 = cl
         .wallet_create_funded_psbt(&[input.clone()], &output, Some(500_000), None, Some(true))
-        .await.unwrap();
+        .await
+        .unwrap();
 
     let psbt = cl.combine_psbt(&[psbt1.psbt.clone(), psbt1.psbt]).await.unwrap();
     assert!(!psbt.is_empty());
@@ -746,7 +795,8 @@ async fn test_finalize_psbt(cl: &Client) {
     output.insert(RANDOM_ADDRESS.to_string(), btc(1.0f64));
     let psbt = cl
         .wallet_create_funded_psbt(&[input.clone()], &output, Some(500_000), None, Some(true))
-        .await.unwrap();
+        .await
+        .unwrap();
 
     let res = cl.finalize_psbt(&psbt.psbt, Some(true)).await.unwrap();
     assert!(!res.complete);
@@ -756,7 +806,8 @@ async fn test_finalize_psbt(cl: &Client) {
 
 async fn test_list_received_by_address(cl: &Client) {
     let addr = cl.get_new_address(None, None).await.unwrap();
-    let txid = cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
+    let txid =
+        cl.send_to_address(&addr, btc(1.0f64), None, None, None, None, None, None).await.unwrap();
 
     let _ = cl.list_received_by_address(Some(&addr), None, None, None).await.unwrap();
     let _ = cl.list_received_by_address(Some(&addr), None, Some(true), None).await.unwrap();
@@ -912,7 +963,8 @@ async fn test_create_wallet(cl: &Client) {
                 wallet_param.passphrase,
                 wallet_param.avoid_reuse,
             )
-            .await.unwrap();
+            .await
+            .unwrap();
 
         assert_eq!(result.name, wallet_param.name);
         let expected_warning = match (wallet_param.passphrase, wallet_param.avoid_reuse) {
@@ -976,7 +1028,8 @@ async fn test_scantxoutset(cl: &Client) {
 
     let utxos = cl
         .scan_tx_out_set_blocking(&[ScanTxOutRequest::Single(format!("addr({})", addr))])
-        .await.unwrap();
+        .await
+        .unwrap();
 
     assert_eq!(utxos.unspents.len(), 2);
     assert_eq!(utxos.success, Some(true));

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -10,7 +10,7 @@
 
 #![deny(unused)]
 
-use bitcoin;
+use bitcoin::{self, PackedLockTime, Sequence};
 #[macro_use]
 extern crate lazy_static;
 use log;
@@ -497,13 +497,13 @@ async fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
 
     let tx = Transaction {
         version: 1,
-        lock_time: 0,
+        lock_time: PackedLockTime(0),
         input: vec![TxIn {
             previous_output: OutPoint {
                 txid: unspent.txid,
                 vout: unspent.vout,
             },
-            sequence: 0xFFFFFFFF,
+            sequence: Sequence(0xFFFFFFFF),
             script_sig: Script::new(),
             witness: Witness::new(),
         }],

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -526,18 +526,18 @@ async fn test_sign_raw_transaction_with_send_raw_transaction(cl: &Client) {
 
     let tx = Transaction {
         version: 1,
-        lock_time: 0,
+        lock_time: PackedLockTime(0),
         input: vec![TxIn {
             previous_output: OutPoint {
-                txid: txid,
+                txid,
                 vout: 0,
             },
             script_sig: Script::new(),
-            sequence: 0xFFFFFFFF,
+            sequence: Sequence(0xFFFFFFFF),
             witness: Witness::new(),
         }],
         output: vec![TxOut {
-            value: (unspent.amount - *FEE - *FEE).as_sat(),
+            value: (unspent.amount - *FEE - *FEE).to_sat(),
             script_pubkey: RANDOM_ADDRESS.script_pubkey(),
         }],
     };


### PR DESCRIPTION
Current bitcoincore-rpc-json (0.16.0) is pinned to bitcoin 0.29.2. Therefore 0.29.2 will be the upgrade target for upstream repos.